### PR TITLE
adds bank code to validation object response

### DIFF
--- a/clabe.gemspec
+++ b/clabe.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'clabe'
-  s.version     = '0.1.0'
+  s.version     = '0.1.1'
   s.date        = '2019-07-30'
   s.summary     = "validator and serializer"
   s.description = "Ruby gem to validate and get details from a CLABE"

--- a/lib/clabe.rb
+++ b/lib/clabe.rb
@@ -1,5 +1,5 @@
 module Clabe
-  ClabeValidation = Struct.new(:is_valid?, :bank_tag, :bank_name, :city, :errors)
+  ClabeValidation = Struct.new(:is_valid?, :bank_tag, :bank_name, :bank_code, :city, :errors)
 
   BANKS = {
     "002" => { tag: 'BANAMEX', name: 'Banco Nacional de México, S.A.' },
@@ -577,6 +577,7 @@ module Clabe
     end
 
     clabe_validation[:is_valid?] = true
+    clabe_validation[:bank_code] = clabe_params[:bank_code]
     clabe_validation[:bank_tag] = clabe_params[:bank][:tag]
     clabe_validation[:bank_name] = clabe_params[:bank][:name]
     clabe_validation[:city] = clabe_params[:city]

--- a/spec/clabe_spec.rb
+++ b/spec/clabe_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe 'Clabe' do
     { clabe: '00000000000000000a', is_valid: false, bank_tag: nil, city: nil },
     { clabe: '002010077777777779', is_valid: false, bank_tag: nil, city: nil },
     { clabe: '000000000000000000', is_valid: false, bank_tag: nil, city: nil },
-    { clabe: '002114016003269412', is_valid: true, bank_tag: 'BANAMEX', city: 'Huixtla' },
-    { clabe: '032180000118359719', is_valid: true, bank_tag: 'IXE', city: 'Atizapan, Chalco, Ciudad de México, Coacalco, Cuautitlán, Cuautitlán Izcalli, Ecatepec, Huehuetoca, Huixquilucan, Ixtapaluca, Los Reyes La Paz, Naucalpan, Nezahualcóyotl, Tecamac, Teotihuacán, Texcoco, Tlalnepantla' }
+    { clabe: '002114016003269412', is_valid: true, bank_tag: 'BANAMEX', city: 'Huixtla', code: '002' },
+    { clabe: '032180000118359719', is_valid: true, bank_tag: 'IXE', city: 'Atizapan, Chalco, Ciudad de México, Coacalco, Cuautitlán, Cuautitlán Izcalli, Ecatepec, Huehuetoca, Huixquilucan, Ixtapaluca, Los Reyes La Paz, Naucalpan, Nezahualcóyotl, Tecamac, Teotihuacán, Texcoco, Tlalnepantla', code: '032' }
   ]
 
   it 'validate' do
@@ -16,15 +16,18 @@ RSpec.describe 'Clabe' do
       expected_validation = data[:is_valid]
       expected_bank_tag = data[:bank_tag]
       expected_city = data[:city]
+      expected_code = data[:code]
 
       clabe_validation = Clabe.validate(raw_clabe)
       actual_validation = clabe_validation.is_valid?
       actual_bank_tag = clabe_validation.bank_tag
       actual_city = clabe_validation.city
+      actual_code = clabe_validation.bank_code
 
       expect(actual_validation).to eq(expected_validation)
       expect(actual_bank_tag).to eq(expected_bank_tag)
       expect(actual_city).to eq(expected_city)
+      expect(actual_code).to eq(expected_code)
     end
   end
 end


### PR DESCRIPTION
Adds the bank code result of a validation to the object returned, so it's available in the result.